### PR TITLE
Improve pubsub monitors

### DIFF
--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -27,8 +27,15 @@ defmodule Redix.PubSub.Connection do
   @impl true
   def init(opts) do
     transport = if(opts[:ssl], do: :ssl, else: :gen_tcp)
-    monitor_absorb_timeout = if(opts[:monitor_absorb_timeout], do: opts[:monitor_absorb_timeout], else: nil)
-    {:ok, monitor_pid} = Redix.PubSub.Connection.Monitor.start_link(conn: self(), absorb_timeout: monitor_absorb_timeout)
+
+    monitor_absorb_timeout =
+      if(opts[:monitor_absorb_timeout], do: opts[:monitor_absorb_timeout], else: nil)
+
+    {:ok, monitor_pid} =
+      Redix.PubSub.Connection.Monitor.start_link(
+        conn: self(),
+        absorb_timeout: monitor_absorb_timeout
+      )
 
     data = %__MODULE__{
       opts: opts,
@@ -467,7 +474,8 @@ defmodule Redix.PubSub.Connection do
 
   # Returns {targets_to_unsubscribe_from, data}.
   defp unsubscribe_pid_from_targets(data, operation, targets, pid)
-       when is_pid(pid), do: unsubscribe_pid_from_targets(data, operation, targets, MapSet.new([pid]))
+       when is_pid(pid),
+       do: unsubscribe_pid_from_targets(data, operation, targets, MapSet.new([pid]))
 
   defp unsubscribe_pid_from_targets(data, operation, targets, pids) do
     target_type =
@@ -501,7 +509,8 @@ defmodule Redix.PubSub.Connection do
   end
 
   defp unsubscribe_pid_from_target(target_state, pid)
-       when is_pid(pid), do: unsubscribe_pid_from_target(target_state, MapSet.new([pid]))
+       when is_pid(pid),
+       do: unsubscribe_pid_from_target(target_state, MapSet.new([pid]))
 
   defp unsubscribe_pid_from_target({:subscribed, subscribers}, pids) do
     if MapSet.size(subscribers) == 1 and MapSet.subset?(subscribers, pids) do

--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -289,19 +289,6 @@ defmodule Redix.PubSub.Connection do
 
   ## Helpers
 
-  defp handle_monitor_disconnect_message(pid, data) do
-    data = update_in(data.monitors, &Map.delete(&1, pid))
-
-    targets = Map.keys(data.subscriptions)
-    channels = for {:channel, channel} <- targets, do: channel
-    patterns = for {:pattern, pattern} <- targets, do: pattern
-
-    with {:ok, data} <- unsubscribe_pid_from_targets(data, :unsubscribe, channels, pid),
-         {:ok, data} <- unsubscribe_pid_from_targets(data, :punsubscribe, patterns, pid) do
-      data
-    end
-  end
-
   defp new_bytes(data, "") do
     {:ok, data}
   end

--- a/lib/redix/pubsub/connection_monitor.ex
+++ b/lib/redix/pubsub/connection_monitor.ex
@@ -1,0 +1,72 @@
+defmodule Redix.PubSub.Connection.Monitor do
+  use GenServer
+
+  @empty Map.new()
+  @absorb_timeout 1_000
+
+  defstruct [
+    :absorb_timeout,
+    :connection,
+    monitored: Map.new(),
+    disconnected: Map.new()
+  ]
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+  def init([conn, nil]) do
+    {:ok, %__MODULE__{connection: conn}}
+  end
+  def init([conn: conn, absorb_timeout: absorb_timeout]) do
+    {:ok, %__MODULE__{connection: conn, absorb_timeout: absorb_timeout}}
+  end
+
+  def add(pid, monitored_pid), do: GenServer.call(pid, {:add, monitored_pid})
+
+  def remove(pid, monitored_pid), do: GenServer.call(pid, {:remove, monitored_pid})
+
+  def flush_monitors(pid), do: flush_monitors(pid, @absorb_timeout)
+
+  def flush_monitors(pid, nil), do: flush_monitors(pid, @absorb_timeout)
+
+  def flush_monitors(pid, absorb_timeout), do: Process.send_after(pid, {:flush}, absorb_timeout)
+
+  ## CALLBACKS ##
+
+  def handle_call({:add,  monitored_pid}, _from, state) do
+    {state, ref} = case state.monitored do
+      %{^monitored_pid => ref} -> {state, ref}
+
+      _ ->
+        ref = Process.monitor(monitored_pid)
+        {put_in(state.monitored[monitored_pid], ref), ref}
+    end
+    {:reply, {:ok, ref}, state}
+  end
+
+  def handle_call({:remove,  monitored_pid}, _from, state) do
+    Process.demonitor(state.monitored[monitored_pid], [:flush])
+    state = update_in(state.monitored, &Map.delete(&1, monitored_pid))
+
+    {:reply, :ok, state}
+  end
+
+  def handle_info({:flush}, %__MODULE__{disconnected: disconnected_map} = state)
+      when disconnected_map == @empty do
+    {:noreply, state}
+  end
+
+  def handle_info({:flush}, %__MODULE__{connection: conn, disconnected: disconnected_map} = state) do
+    :gen_statem.cast(conn, {:monitors_disconnected, disconnected_map})
+    state = %{state | disconnected: Map.new()}
+
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, monitored_pid, _reason}, state) do
+    state = update_in(state.monitored, &Map.delete(&1, monitored_pid))
+    state = put_in(state.disconnected[monitored_pid], ref)
+
+    flush_monitors(self())
+    {:noreply, state}
+  end
+
+end

--- a/lib/redix/pubsub/connection_monitor.ex
+++ b/lib/redix/pubsub/connection_monitor.ex
@@ -61,12 +61,11 @@ defmodule Redix.PubSub.Connection.Monitor do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, ref, :process, monitored_pid, _reason}, state) do
+  def handle_info({:DOWN, ref, :process, monitored_pid, _reason}, %__MODULE__{absorb_timeout: absorb_timeout} = state) do
     state = update_in(state.monitored, &Map.delete(&1, monitored_pid))
     state = put_in(state.disconnected[monitored_pid], ref)
 
-    flush_monitors(self())
+    flush_monitors(self(), absorb_timeout)
     {:noreply, state}
   end
-
 end

--- a/lib/redix/pubsub/connection_monitor.ex
+++ b/lib/redix/pubsub/connection_monitor.ex
@@ -12,10 +12,12 @@ defmodule Redix.PubSub.Connection.Monitor do
   ]
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
   def init([conn, nil]) do
     {:ok, %__MODULE__{connection: conn}}
   end
-  def init([conn: conn, absorb_timeout: absorb_timeout]) do
+
+  def init(conn: conn, absorb_timeout: absorb_timeout) do
     {:ok, %__MODULE__{connection: conn, absorb_timeout: absorb_timeout}}
   end
 
@@ -31,18 +33,21 @@ defmodule Redix.PubSub.Connection.Monitor do
 
   ## CALLBACKS ##
 
-  def handle_call({:add,  monitored_pid}, _from, state) do
-    {state, ref} = case state.monitored do
-      %{^monitored_pid => ref} -> {state, ref}
+  def handle_call({:add, monitored_pid}, _from, state) do
+    {state, ref} =
+      case state.monitored do
+        %{^monitored_pid => ref} ->
+          {state, ref}
 
-      _ ->
-        ref = Process.monitor(monitored_pid)
-        {put_in(state.monitored[monitored_pid], ref), ref}
-    end
+        _ ->
+          ref = Process.monitor(monitored_pid)
+          {put_in(state.monitored[monitored_pid], ref), ref}
+      end
+
     {:reply, {:ok, ref}, state}
   end
 
-  def handle_call({:remove,  monitored_pid}, _from, state) do
+  def handle_call({:remove, monitored_pid}, _from, state) do
     Process.demonitor(state.monitored[monitored_pid], [:flush])
     state = update_in(state.monitored, &Map.delete(&1, monitored_pid))
 
@@ -61,7 +66,10 @@ defmodule Redix.PubSub.Connection.Monitor do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, ref, :process, monitored_pid, _reason}, %__MODULE__{absorb_timeout: absorb_timeout} = state) do
+  def handle_info(
+        {:DOWN, ref, :process, monitored_pid, _reason},
+        %__MODULE__{absorb_timeout: absorb_timeout} = state
+      ) do
     state = update_in(state.monitored, &Map.delete(&1, monitored_pid))
     state = put_in(state.disconnected[monitored_pid], ref)
 

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -15,7 +15,8 @@ defmodule Redix.StartOptions do
     backoff_initial: 500,
     backoff_max: 30000,
     exit_on_disconnection: false,
-    timeout: 5000
+    timeout: 5000,
+    monitor_absorb_timeout: 1_000,
   ]
 
   @allowed_options [:host, :port, :database, :password, :name, :sentinel] ++

--- a/lib/redix/start_options.ex
+++ b/lib/redix/start_options.ex
@@ -16,7 +16,7 @@ defmodule Redix.StartOptions do
     backoff_max: 30000,
     exit_on_disconnection: false,
     timeout: 5000,
-    monitor_absorb_timeout: 1_000,
+    monitor_absorb_timeout: 1_000
   ]
 
   @allowed_options [:host, :port, :database, :password, :name, :sentinel] ++

--- a/test/redix/pubsub_test.exs
+++ b/test/redix/pubsub_test.exs
@@ -11,7 +11,7 @@ defmodule Redix.PubSubTest do
   @port 6380
 
   setup do
-    {:ok, pubsub} = PubSub.start_link(port: @port)
+    {:ok, pubsub} = PubSub.start_link(port: @port, monitor_absorb_timeout: 0)
     {:ok, conn} = Redix.start_link(port: @port)
     {:ok, %{pubsub: pubsub, conn: conn}}
   end

--- a/test/redix/sentinel_test.exs
+++ b/test/redix/sentinel_test.exs
@@ -62,7 +62,8 @@ defmodule Redix.SentinelTest do
 
   test "sentinel supports password", %{sentinel_config: sentinel_config} do
     sentinel_config =
-      Keyword.merge(sentinel_config,
+      Keyword.merge(
+        sentinel_config,
         password: "sentinel-password",
         sentinels: ["redis://localhost:26383"]
       )

--- a/test/redix_test.exs
+++ b/test/redix_test.exs
@@ -74,7 +74,8 @@ defmodule RedixTest do
 
     test "using a rediss:// url, ignoring certificate" do
       {:ok, pid} =
-        Redix.start_link("rediss://localhost:6384/3",
+        Redix.start_link(
+          "rediss://localhost:6384/3",
           socket_opts: [verify: :verify_none, reuse_sessions: false]
         )
 
@@ -86,7 +87,8 @@ defmodule RedixTest do
         Process.flag(:trap_exit, true)
 
         assert {:error, error} =
-                 Redix.start_link("rediss://localhost:6384/3",
+                 Redix.start_link(
+                   "rediss://localhost:6384/3",
                    socket_opts: [reuse_sessions: false],
                    sync_connect: true
                  )


### PR DESCRIPTION
Creating a new process to handle the subscribers' monitors, sometimes the process which holds all the subscribers die and all the subscribers also die flooding the PUBSUB process with a bunch of DOWN messages.

In my case, I have a phoenix application serving a WebSocket interface over Phoenix Channels so when the client application connects to Phoenix it needs to join in thousands of feed to receive all the system updates, yeah it is HUGE application. 

When the client closes the browser, for example, the process that holds the WebSockets connection also holds all the subscribers.

![image](https://user-images.githubusercontent.com/5301437/73508719-9a022a80-43bb-11ea-83db-c26d52b0420e.png)

Some results.

The first alternative we increased a lot the schedulers usage

![Screenshot from 2020-01-30 23-26-24](https://user-images.githubusercontent.com/5301437/73508665-6de6a980-43bb-11ea-9e62-6faace75885b.png)
 
so we need to handle the batch more efficiently using MapSet operations, for that reason this PR gets so big.

![Screenshot from 2020-01-30 23-27-41](https://user-images.githubusercontent.com/5301437/73508675-717a3080-43bb-11ea-859a-14fa161f3a05.png)
